### PR TITLE
Add codemeta file for software preservation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Please cite Ewens, Peters and Wang (2019) work "[Acquisition prices and the meas
 
 - load the txt [index file](https://github.com/michaelewens/md_n_a_10K/blob/master/download_log_filelist.txt).  This file is a simple list of the file names of MD&A text from the original download.  Note that you could probably just get the full set of statements, save the output of `ls` or similar to a variable and loop over the files.  
 - the column `Filer` is a mapping to the raw text files associated with the 10-K scrape.   So for row 6 in that file, the respective txt file is `119173.txt`
-- download the [txt files from here](https://data.caltech.edu/records/1249) (they are too big for Github).   For space reasons, the files were split into folders.  They will have to be combined into one folder if the code below is to work.
+- download the [txt files from here](https://doi.org/10.22002/D1.1249) (they are too big for GitHub).   For space reasons, the files were split into folders.  They will have to be combined into one folder if the code below is to work.
 - We ask that this data not be forwarded on to others.  This ensures that everyone receives the latest version of the data that's available.
 - use the [Python script](https://github.com/michaelewens/MD-A-10K/blob/master/example_procesing.py) -- or your code of choice -- to loop through the text files and grab what you need.  The text files have headers (unfortunately, sometimes more than one because data) like this:
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # MD&A text from 10-K filings
 
+[![DOI](https://data.caltech.edu/badge/192034546.svg)](https://data.caltech.edu/badge/latestdoi/192034546)
+
 This repository contains an "index" file that can be used to process the raw MD&A data parsed [using this code](https://github.com/apodobytko/10K-MDA-Section), which is a fork/update of [this repo](https://github.com/rflugum/10K-MDA-Section).   After following the instructions below, you can have your own panel database of public firm MD&A text.  
 
 As an example of how this data can be used, Ewens, Peters and Wang (2019) searched all the MD&A sections for references to personnel or human capital risk (following Eisfeldt and Papanikolaou, 2013) to sort public firms and compare their organizational capital stocks:

--- a/codemeta.json
+++ b/codemeta.json
@@ -1,0 +1,23 @@
+{
+  "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
+  "@type": "SoftwareSourceCode",
+  "codeRepository": "https://github.com/michaelewens/MD-A-10K",
+  "name": "MD-A-10K",
+  "issueTracker": "https://github.com/michaelewens/MD-A-10K/issues",
+  "license": "https://spdx.org/licenses/MI",
+  "version": "v0.0.1",
+  "name": "MD&A statements from public firms: 2002-2018",
+  "authors": [
+    {
+      "nameType": "Personal",
+      "name": "Ewens, Michael",
+      "givenName": "Michael",
+      "familyName": "Ewens",
+      "affiliation": "Caltech"
+    }
+  ],
+  "description": "Text and headers from MD&A sections found in public firm 10-K statements.",
+  "keywords": [
+    "finance", "text", "disclosure", "risks"
+  ]
+}


### PR DESCRIPTION
Thanks for your submission to CaltechDATA!  You can also preserve this GitHub
repository using the automated integration in CaltechDATA. This PR includes a
codemeta file, which lets you control the metadata that shows up
CaltechDATA. Please check that the codemeta.json file is accurate. You can set up software preservation using CaltechDATA following these steps:

1.  Log into data.caltech.edu with your Caltech (access.caltech) account credentials.
2.  Select GitHub from the profile menu in the upper right hand side of the screen.
3.  Enter your GitHub credentials
4.  Select this GitHub repository (You might have to refresh the page for the buttons to activate).
5.  Make a new release in GitHub.

The DOI image I added to your README will show up once your code is preserved.

Let me know if you have any questions,

Tom Morrell
Research Data Specialist, Caltech Library